### PR TITLE
Use latest PHP 7 version

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -60,7 +60,7 @@ sudo service php5-fpm restart
 # @todo: PHP5 config files
 
 # @todo: PHP7 setup
-wget http://repos.zend.com/zend-server/early-access/php7/php-7.0-270815-DEB-x86_64.tar.gz
+wget http://repos.zend.com/zend-server/early-access/php7/php-7.0-latest-DEB-x86_64.tar.gz
 sudo tar zxPf php-7.*.tar.gz
 sudo cp ~/maat/php7/etc-initd-php7fpm /etc/init.d/php7-fpm
 sudo chmod a+x /etc/init.d/php7-fpm


### PR DESCRIPTION
The current URL to install PHP 7 results in a 404. Maybe use the latest tar.gz which should always be up-to-date?
